### PR TITLE
feat: add forum admin view

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,8 @@ import MeditacionesPage from "@/pages/MeditacionesPage";
 import SobreNosotrosPage from "@/pages/SobreNosotrosPage";
 import SettingsPage from "@/pages/SettingsPage";
 import AppLayout from "@/components/layout/AppLayout";
-import AdminJobsPage from "@/pages/adminJobsPage";
+import AdminJobsPage from "@/pages/AdminJobsPage";
+import ForosPage from "@/pages/ForosPage";
 
 function Router() {
   return (
@@ -26,6 +27,7 @@ function Router() {
         <Route path="/eventos" component={EventosPage} />
         <Route path="/oraciones" component={OracionesPage} />
         <Route path="/cursos" component={CursosPage} />
+        <Route path="/foros" component={ForosPage} />
         <Route path="/admin/jobs" component={AdminJobsPage} />
         <Route path="/donaciones" component={DonacionesPage} />
         <Route path="/meditaciones" component={MeditacionesPage} />

--- a/client/src/components/TopSelling.tsx
+++ b/client/src/components/TopSelling.tsx
@@ -43,10 +43,10 @@ export default function TopSelling({ products, isLoading }: TopSellingProps) {
       <div className="space-y-4">
         {products.map((product) => (
           <div key={product.id} className="flex items-center space-x-4">
-            <img 
-              src={product.imageUrl} 
+            <img
+              src={product.imageUrl ?? ""}
               alt={product.name}
-              className="w-16 h-16 rounded-lg object-cover" 
+              className="w-16 h-16 rounded-lg object-cover"
             />
             <div className="flex-1">
               <h4 className="font-medium text-neutral-800">{product.name}</h4>

--- a/client/src/components/layout/MobileNav.tsx
+++ b/client/src/components/layout/MobileNav.tsx
@@ -95,6 +95,16 @@ export default function MobileNav({ isOpen, onClose }: MobileNavProps) {
             </a>
           </li>
           <li>
+            <a
+              href="#"
+              onClick={(e) => { e.preventDefault(); handleNavigation("/foros"); }}
+              className={`flex items-center space-x-3 px-4 py-3 rounded-lg ${isActive("/foros") ? 'bg-primary bg-opacity-10 text-primary font-medium' : 'hover:bg-neutral-100 text-neutral-600'}`}
+            >
+              <i className="ri-discuss-line text-xl"></i>
+              <span>Foros</span>
+            </a>
+          </li>
+          <li>
             <a 
               href="#" 
               onClick={(e) => { e.preventDefault(); handleNavigation("/configuracion"); }}

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -71,6 +71,16 @@ export default function Sidebar() {
             </a>
           </li>
           <li>
+            <a
+              href="#"
+              onClick={(e) => { e.preventDefault(); setLocation("/foros"); }}
+              className={`flex items-center space-x-3 px-4 py-3 rounded-lg ${isActive("/foros") ? 'bg-primary bg-opacity-10 text-primary font-medium' : 'hover:bg-neutral-100 text-neutral-600'}`}
+            >
+              <i className="ri-discuss-line text-xl"></i>
+              <span>Foros</span>
+            </a>
+          </li>
+          <li>
             <a 
               href="#" 
               onClick={(e) => { e.preventDefault(); setLocation("/empleos"); }}

--- a/client/src/pages/ForosPage.tsx
+++ b/client/src/pages/ForosPage.tsx
@@ -1,0 +1,82 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { PlusIcon } from "@/lib/icons";
+import { Helmet } from "react-helmet";
+
+interface Subforo {
+  id: number;
+  nombre: string;
+}
+
+interface ForoCurso {
+  id: number;
+  curso: string;
+  subforos: Subforo[];
+}
+
+export default function ForosPage() {
+  const foros: ForoCurso[] = [
+    {
+      id: 1,
+      curso: "Introducción a la Biblia",
+      subforos: [
+        { id: 1, nombre: "General" },
+        { id: 2, nombre: "Lección 1" },
+        { id: 3, nombre: "Lección 2" },
+      ],
+    },
+    {
+      id: 2,
+      curso: "Discipulado Básico",
+      subforos: [
+        { id: 1, nombre: "General" },
+        { id: 2, nombre: "Unidad 1" },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <Helmet>
+        <title>Administración de Foros</title>
+      </Helmet>
+      <div className="p-6 space-y-6">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Administración de Foros</CardTitle>
+            <Button>
+              <PlusIcon className="mr-2 h-4 w-4" />
+              Nuevo Foro
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Curso</TableHead>
+                  <TableHead>Subforos</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {foros.map((foro) => (
+                  <TableRow key={foro.id}>
+                    <TableCell className="font-medium">{foro.curso}</TableCell>
+                    <TableCell>
+                      <ul className="list-disc pl-4 space-y-1">
+                        {foro.subforos.map((subforo) => (
+                          <li key={subforo.id}>{subforo.nombre}</li>
+                        ))}
+                      </ul>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}
+

--- a/client/src/pages/ProductsPage.tsx
+++ b/client/src/pages/ProductsPage.tsx
@@ -108,8 +108,8 @@ export default function ProductsPage() {
                   filteredProducts.map((product) => (
                     <Card key={product.id} className="overflow-hidden">
                       <div className="relative">
-                        <img 
-                          src={product.imageUrl}
+                        <img
+                          src={product.imageUrl ?? ""}
                           alt={product.name}
                           className="w-full h-48 object-cover"
                         />


### PR DESCRIPTION
## Summary
- add new forums admin page to manage course forums
- link forum management into router and nav menus
- fix product image fields to satisfy TypeScript checks

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b344ebdc188327b47b4793f36cf1f0

## Summary by Sourcery

Add a new forums administration view with routing and navigation links, and fix TypeScript issues in product image handling and imports

New Features:
- Introduce ForosPage for managing course forums with a table and “New Forum” action
- Add “Foros” link to sidebar navigation
- Add “Foros” link to mobile navigation
- Register "/foros" route in the application router

Bug Fixes:
- Provide default empty string for product.imageUrl to satisfy TypeScript null checks
- Correct import path casing for AdminJobsPage