### PR TITLE
Add mock forum data and enhance forum layout

### DIFF
--- a/client/src/components/forum/recent-activity.tsx
+++ b/client/src/components/forum/recent-activity.tsx
@@ -1,87 +1,86 @@
 import { useQuery } from "@tanstack/react-query";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MessageSquare, Plus, Heart } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { es } from "date-fns/locale";
 import { Link } from "wouter";
+import { mockRecentActivity } from "@/data/mock-forum";
 
 export default function RecentActivity() {
-  const { data: activity, isLoading } = useQuery({
+  const { data: activity = mockRecentActivity, isLoading } = useQuery({
     queryKey: ["/api/activity/recent"],
+    queryFn: async () => mockRecentActivity,
+    initialData: mockRecentActivity,
   });
 
   return (
-    <div className="mt-12">
-      <h3 className="text-xl font-bold text-foreground mb-6">Actividad Reciente</h3>
-      
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="divide-y divide-border">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i} className="p-4">
-                  <div className="flex items-start space-x-3">
-                    <Skeleton className="w-8 h-8 rounded-full" />
-                    <div className="flex-1 space-y-2">
-                      <Skeleton className="h-4 w-3/4" />
-                      <Skeleton className="h-3 w-1/2" />
-                    </div>
+    <Card>
+      <CardContent className="p-0">
+        {isLoading ? (
+          <div className="divide-y divide-border">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="p-4">
+                <div className="flex items-start space-x-3">
+                  <Skeleton className="w-8 h-8 rounded-full" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-3/4" />
+                    <Skeleton className="h-3 w-1/2" />
                   </div>
                 </div>
-              ))}
-            </div>
-          ) : activity && activity.length > 0 ? (
-            <div className="divide-y divide-border">
-              {activity.map((item: any, index: number) => (
-                <div key={`${item.type}-${item.id}-${index}`} className="p-4 hover:bg-muted/50 transition-colors">
-                  <div className="flex items-start space-x-3">
-                    <div className={`activity-icon ${item.type === 'post' ? 'comment' : item.type === 'thread' ? 'thread' : 'heart'}`}>
-                      {item.type === 'post' ? (
-                        <MessageSquare size={14} />
-                      ) : item.type === 'thread' ? (
-                        <Plus size={14} />
-                      ) : (
-                        <Heart size={14} />
-                      )}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm text-foreground">
-                        <span className="font-medium">{item.authorName || "Usuario Anónimo"}</span>
-                        {item.type === 'post' ? " respondió en " : item.type === 'thread' ? " creó un nuevo tema " : " agradeció por el apoyo en "}
-                        <Link href={`/thread/${item.threadId}`}>
-                          <span className="text-primary hover:underline cursor-pointer">
-                            "{item.threadTitle}"
-                          </span>
-                        </Link>
-                      </p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        {item.categoryName} • {formatDistanceToNow(new Date(item.timestamp), { 
-                          addSuffix: true, 
-                          locale: es 
-                        })}
-                      </p>
-                    </div>
+              </div>
+            ))}
+          </div>
+        ) : activity && activity.length > 0 ? (
+          <div className="divide-y divide-border">
+            {activity.map((item: any, index: number) => (
+              <div key={`${item.type}-${item.id}-${index}`} className="p-4 hover:bg-muted/50 transition-colors">
+                <div className="flex items-start space-x-3">
+                  <div className={`activity-icon ${item.type === 'post' ? 'comment' : item.type === 'thread' ? 'thread' : 'heart'}`}>
+                    {item.type === 'post' ? (
+                      <MessageSquare size={14} />
+                    ) : item.type === 'thread' ? (
+                      <Plus size={14} />
+                    ) : (
+                      <Heart size={14} />
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-foreground">
+                      <span className="font-medium">{item.authorName || "Usuario Anónimo"}</span>
+                      {item.type === 'post' ? " respondió en " : item.type === 'thread' ? " creó un nuevo tema " : " agradeció por el apoyo en "}
+                      <Link href={`/thread/${item.threadId}`}>
+                        <span className="text-primary hover:underline cursor-pointer">
+                          "{item.threadTitle}"
+                        </span>
+                      </Link>
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {item.categoryName} • {formatDistanceToNow(new Date(item.timestamp), {
+                        addSuffix: true,
+                        locale: es
+                      })}
+                    </p>
                   </div>
                 </div>
-              ))}
-            </div>
-          ) : (
-            <div className="p-8 text-center">
-              <p className="text-muted-foreground">No hay actividad reciente disponible.</p>
-            </div>
-          )}
-          
-          {activity && activity.length > 0 && (
-            <div className="p-4 border-t border-border text-center">
-              <Button variant="ghost" className="text-primary hover:underline">
-                Ver toda la actividad
-              </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="p-8 text-center">
+            <p className="text-muted-foreground">No hay actividad reciente disponible.</p>
+          </div>
+        )}
+
+        {activity && activity.length > 0 && (
+          <div className="p-4 border-t border-border text-center">
+            <Button variant="ghost" className="text-primary hover:underline">
+              Ver toda la actividad
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/client/src/components/forum/subforum-list.tsx
+++ b/client/src/components/forum/subforum-list.tsx
@@ -2,18 +2,21 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { MessageSquare, Users, Eye } from "lucide-react";
+import { MessageSquare, Users } from "lucide-react";
 import { Link } from "wouter";
 import { formatDistanceToNow } from "date-fns";
 import { es } from "date-fns/locale";
+import { mockSubforums } from "@/data/mock-forum";
 
 interface SubforumListProps {
   categoryId: number;
 }
 
 export default function SubforumList({ categoryId }: SubforumListProps) {
-  const { data: subforums, isLoading } = useQuery({
+  const { data: subforums = mockSubforums[categoryId] || [], isLoading } = useQuery({
     queryKey: [`/api/categories/${categoryId}/subforums`],
+    queryFn: async () => mockSubforums[categoryId] || [],
+    initialData: mockSubforums[categoryId] || [],
     enabled: !!categoryId,
   });
 

--- a/client/src/data/mock-forum.ts
+++ b/client/src/data/mock-forum.ts
@@ -1,0 +1,158 @@
+export const mockSubforums: Record<number, any[]> = {
+  1: [
+    {
+      id: 1,
+      name: "Depresión",
+      slug: "depresion",
+      description: "Espacio para compartir experiencias y consejos sobre la depresión.",
+      threadCount: 42,
+      memberCount: 130,
+      lastActivity: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+    },
+    {
+      id: 2,
+      name: "Ansiedad",
+      slug: "ansiedad",
+      description: "Manejo de la ansiedad y técnicas de relajación.",
+      threadCount: 36,
+      memberCount: 98,
+      lastActivity: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
+    },
+  ],
+  2: [
+    {
+      id: 3,
+      name: "Historias de superación",
+      slug: "historias-superacion",
+      description: "Relatos que inspiran a otros.",
+      threadCount: 15,
+      memberCount: 80,
+      lastActivity: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: 4,
+      name: "Consejos diarios",
+      slug: "consejos-diarios",
+      description: "Pequeños hábitos para mejorar cada día.",
+      threadCount: 20,
+      memberCount: 65,
+      lastActivity: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    },
+  ],
+  3: [
+    {
+      id: 5,
+      name: "Familia",
+      slug: "familia",
+      description: "Apoyo en relaciones familiares.",
+      threadCount: 22,
+      memberCount: 110,
+      lastActivity: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: 6,
+      name: "Pareja",
+      slug: "pareja",
+      description: "Consejos para relaciones de pareja.",
+      threadCount: 18,
+      memberCount: 97,
+      lastActivity: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+    },
+  ],
+};
+
+export const mockCategories = [
+  {
+    id: 1,
+    name: "Salud Mental",
+    description: "Espacio seguro para hablar sobre salud mental.",
+    icon: "brain",
+    color: "text-purple-600",
+    slug: "salud-mental",
+    schedule: "Lunes 18:00",
+    maxParticipants: 50,
+    stats: {
+      threadCount: 134,
+      postCount: 582,
+      memberCount: 321,
+      lastActivity: {
+        threadId: 1,
+        userId: "anon1",
+        timestamp: new Date(Date.now() - 15 * 60 * 1000),
+      },
+    },
+    subforums: mockSubforums[1].map(({ id, name }) => ({ id, name })),
+  },
+  {
+    id: 2,
+    name: "Autoestima y Motivación",
+    description: "Comparte técnicas para mejorar autoestima y mantener la motivación.",
+    icon: "sun",
+    color: "text-yellow-600",
+    slug: "autoestima-motivacion",
+    stats: {
+      threadCount: 98,
+      postCount: 421,
+      memberCount: 210,
+      lastActivity: {
+        threadId: 2,
+        userId: "anon2",
+        timestamp: new Date(Date.now() - 60 * 60 * 1000),
+      },
+    },
+    subforums: mockSubforums[2].map(({ id, name }) => ({ id, name })),
+  },
+  {
+    id: 3,
+    name: "Relaciones y Apoyo",
+    description: "Consejos y acompañamiento en relaciones personales.",
+    icon: "hands-helping",
+    color: "text-blue-600",
+    slug: "relaciones-apoyo",
+    schedule: "Viernes 20:00",
+    stats: {
+      threadCount: 76,
+      postCount: 305,
+      memberCount: 180,
+      lastActivity: {
+        threadId: 3,
+        userId: "anon3",
+        timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      },
+    },
+    subforums: mockSubforums[3].map(({ id, name }) => ({ id, name })),
+  },
+];
+
+export const mockRecentActivity = [
+  {
+    id: 1,
+    type: "thread",
+    authorName: "Ana",
+    threadId: 101,
+    threadTitle: "Cómo manejo la ansiedad",
+    categoryName: "Salud Mental",
+    timestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 2,
+    type: "post",
+    authorName: "Luis",
+    threadId: 102,
+    threadTitle: "Buscando motivación diaria",
+    categoryName: "Autoestima y Motivación",
+    timestamp: new Date(Date.now() - 40 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 3,
+    type: "thanks",
+    authorName: "María",
+    threadId: 103,
+    threadTitle: "Consejos para la relación",
+    categoryName: "Relaciones y Apoyo",
+    timestamp: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+  },
+];
+
+export default { mockCategories, mockSubforums, mockRecentActivity };
+

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -100,3 +100,18 @@
   height: 300px;
   position: relative;
 }
+
+@layer components {
+  .activity-icon {
+    @apply w-8 h-8 rounded-full flex items-center justify-center text-white;
+  }
+  .activity-icon.comment {
+    @apply bg-primary;
+  }
+  .activity-icon.thread {
+    @apply bg-secondary;
+  }
+  .activity-icon.heart {
+    @apply bg-accent;
+  }
+}

--- a/client/src/pages/ForosPage.tsx
+++ b/client/src/pages/ForosPage.tsx
@@ -7,210 +7,219 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Heart, Eye, Users, MessageCircle, Info, UserPlus, Calendar, Mail } from "lucide-react";
+import { Heart, Eye, Users, MessageCircle, Info, UserPlus } from "lucide-react";
 import { Link } from "wouter";
+import { mockCategories } from "@/data/mock-forum";
 
 export default function Guest() {
-  const { data: categories, isLoading: categoriesLoading } = useQuery({
+  const { data: categories = mockCategories, isLoading: categoriesLoading } = useQuery({
     queryKey: ["/api/categories"],
-    retry: false,
-  });
-
-  const { data: recentActivity, isLoading: activityLoading } = useQuery({
-    queryKey: ["/api/activity/recent"],
+    queryFn: async () => mockCategories,
+    initialData: mockCategories,
     retry: false,
   });
 
   return (
     <div className="min-h-screen bg-background">
-       
+      <CrisisBanner />
+      <header className="fixed top-0 inset-x-0 z-40 bg-gradient-to-r from-primary to-purple-600 text-primary-foreground shadow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+          <h1 className="text-xl font-bold">Foros</h1>
+          <Link href="/">
+            <Button variant="ghost" size="sm" className="text-primary-foreground hover:bg-primary-foreground/20">
+              Inicio
+            </Button>
+          </Link>
+        </div>
+      </header>
+
       {/* Main Content with padding for fixed header */}
       <div className="pt-32 sm:pt-36">
-
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-          {/* Guest Sidebar */}
-          <aside className="lg:col-span-1">
-            {/* Visitor Info */}
-            <Card className="mb-6 border-blue-200 bg-blue-50/50 dark:border-blue-800 dark:bg-blue-950/20">
-              <CardHeader>
-                <CardTitle className="text-lg flex items-center text-blue-800 dark:text-blue-200">
-                  <Eye size={20} className="mr-2" />
-                  Modo Visitante
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <p className="text-sm text-blue-700 dark:text-blue-300">
-                  Estás explorando SafeSpace como visitante. Puedes leer todos los temas y obtener una vista completa de nuestra comunidad.
-                </p>
-                <div className="space-y-2 text-xs text-blue-600 dark:text-blue-400">
-                  <div className="flex items-center">
-                    <span className="w-2 h-2 bg-green-500 rounded-full mr-2"></span>
-                    Leer todos los temas
-                  </div>
-                  <div className="flex items-center">
-                    <span className="w-2 h-2 bg-green-500 rounded-full mr-2"></span>
-                    Ver respuestas y comentarios
-                  </div>
-                  <div className="flex items-center">
-                    <span className="w-2 h-2 bg-red-500 rounded-full mr-2"></span>
-                    Crear temas o responder
-                  </div>
-                  <div className="flex items-center">
-                    <span className="w-2 h-2 bg-red-500 rounded-full mr-2"></span>
-                    Guardar o suscribirse
-                  </div>
-                </div>
-                <a href="/api/login">
-                  <Button size="sm" className="w-full mt-4">
-                    Unirse para Participar
-                  </Button>
-                </a>
-              </CardContent>
-            </Card>
-
-            {/* Community Stats */}
-            <Card className="mb-6">
-              <CardHeader>
-                <CardTitle className="text-lg">Estadísticas de la Comunidad</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="flex items-center text-muted-foreground">
-                    <Users size={14} className="mr-2" />
-                    Miembros activos
-                  </span>
-                  <Badge variant="secondary">2,847</Badge>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="flex items-center text-muted-foreground">
-                    <MessageCircle size={14} className="mr-2" />
-                    Temas de apoyo
-                  </span>
-                  <Badge variant="secondary">1,234</Badge>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="flex items-center text-muted-foreground">
-                    <Heart size={14} className="mr-2" />
-                    Mensajes de apoyo
-                  </span>
-                  <Badge variant="secondary">8,956</Badge>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Navigation back */}
-            <Card>
-              <CardContent className="p-4">
-                <Link href="/">
-                  <Button variant="outline" className="w-full">
-                    Volver al Inicio
-                  </Button>
-                </Link>
-              </CardContent>
-            </Card>
-          </aside>
-
-          <div className="lg:col-span-3">
-            {/* Welcome Message */}
-            <Alert className="mb-8">
-              <Info className="h-4 w-4" />
-              <AlertDescription>
-                <strong>Bienvenido a SafeSpace.</strong> Estás explorando como visitante. 
-                Puedes leer todos los temas y ver cómo nuestra comunidad se apoya mutuamente. 
-                Si deseas participar activamente, puedes unirte de forma anónima en cualquier momento.
-              </AlertDescription>
-            </Alert>
-
-            {/* Categories */}
-            <section className="mb-12">
-              <div className="flex items-center justify-between mb-6">
-                <h2 className="text-2xl font-bold text-foreground">Categorías de Apoyo</h2>
-                <Badge variant="outline">Solo lectura</Badge>
-              </div>
-              
-              {categoriesLoading ? (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  {Array.from({ length: 4 }).map((_, i) => (
-                    <Card key={i} className="animate-pulse">
-                      <CardContent className="p-6">
-                        <div className="h-6 bg-muted rounded mb-4"></div>
-                        <div className="h-4 bg-muted rounded mb-2"></div>
-                        <div className="h-4 bg-muted rounded w-3/4"></div>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-              ) : categories && categories.length > 0 ? (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  {categories.map((category: any) => (
-                    <CategoryCard 
-                      key={category.id} 
-                      category={{
-                        ...category,
-                        stats: {
-                          threadCount: Math.floor(Math.random() * 200) + 50,
-                          postCount: Math.floor(Math.random() * 1000) + 200,
-                          memberCount: Math.floor(Math.random() * 500) + 100,
-                        },
-                        subforums: category.subforums || []
-                      }} 
-                    />
-                  ))}
-                </div>
-              ) : (
-                <Card>
-                  <CardContent className="p-12 text-center">
-                    <MessageCircle className="mx-auto mb-4 text-muted-foreground" size={48} />
-                    <h3 className="text-xl font-semibold mb-2">Aún no hay categorías</h3>
-                    <p className="text-muted-foreground">
-                      La comunidad está en proceso de configuración. Pronto habrá espacios de apoyo disponibles.
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+            {/* Guest Sidebar */}
+            <aside className="lg:col-span-1">
+              <div className="space-y-6 sticky top-24">
+                {/* Visitor Info */}
+                <Card className="border-none shadow-sm bg-gradient-to-br from-primary/10 to-primary/5 dark:from-primary/20 dark:to-primary/10">
+                  <CardHeader>
+                    <CardTitle className="text-lg flex items-center text-primary">
+                      <Eye size={20} className="mr-2" />
+                      Modo Visitante
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <p className="text-sm text-foreground/80">
+                      Estás explorando SafeSpace como visitante. Puedes leer todos los temas y obtener una vista completa de nuestra comunidad.
                     </p>
+                    <div className="space-y-2 text-xs text-foreground/60">
+                      <div className="flex items-center">
+                        <span className="w-2 h-2 bg-green-500 rounded-full mr-2"></span>
+                        Leer todos los temas
+                      </div>
+                      <div className="flex items-center">
+                        <span className="w-2 h-2 bg-green-500 rounded-full mr-2"></span>
+                        Ver respuestas y comentarios
+                      </div>
+                      <div className="flex items-center">
+                        <span className="w-2 h-2 bg-red-500 rounded-full mr-2"></span>
+                        Crear temas o responder
+                      </div>
+                      <div className="flex items-center">
+                        <span className="w-2 h-2 bg-red-500 rounded-full mr-2"></span>
+                        Guardar o suscribirse
+                      </div>
+                    </div>
+                    <a href="/api/login">
+                      <Button size="sm" className="w-full mt-4">
+                        Unirse para Participar
+                      </Button>
+                    </a>
                   </CardContent>
                 </Card>
-              )}
-            </section>
 
-            {/* Recent Activity */}
-            <section>
-              <div className="flex items-center justify-between mb-6">
-                <h2 className="text-2xl font-bold text-foreground">Actividad Reciente</h2>
-                <Badge variant="outline">Últimas 24 horas</Badge>
+                {/* Community Stats */}
+                <Card className="border-none shadow-sm">
+                  <CardHeader>
+                    <CardTitle className="text-lg">Estadísticas de la Comunidad</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="flex items-center text-muted-foreground">
+                        <Users size={14} className="mr-2" />
+                        Miembros activos
+                      </span>
+                      <Badge variant="secondary">2,847</Badge>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="flex items-center text-muted-foreground">
+                        <MessageCircle size={14} className="mr-2" />
+                        Temas de apoyo
+                      </span>
+                      <Badge variant="secondary">1,234</Badge>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="flex items-center text-muted-foreground">
+                        <Heart size={14} className="mr-2" />
+                        Mensajes de apoyo
+                      </span>
+                      <Badge variant="secondary">8,956</Badge>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* Navigation back */}
+                <Card className="border-none shadow-sm">
+                  <CardContent className="p-4">
+                    <Link href="/">
+                      <Button variant="outline" className="w-full">
+                        Volver al Inicio
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
               </div>
-              
-              <RecentActivity />
-            </section>
+            </aside>
 
-            {/* Join CTA */}
-            <Card className="mt-12 bg-gradient-to-r from-primary/10 to-purple-600/10 border-primary/20">
-              <CardContent className="p-8 text-center">
-                <Heart className="mx-auto mb-4 text-primary" size={48} />
-                <h3 className="text-2xl font-bold mb-4">¿Listo para Unirte a la Comunidad?</h3>
-                <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
-                  Has visto cómo nuestra comunidad se apoya mutuamente. Únete de forma anónima 
-                  para participar en conversaciones, crear temas y recibir apoyo personalizado.
-                </p>
-                <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                  <a href="/api/login">
-                    <Button size="lg" className="bg-primary hover:bg-primary/90">
-                      <UserPlus className="mr-2" size={20} />
-                      Unirse de Forma Anónima
-                    </Button>
-                  </a>
-                  <Link href="/">
-                    <Button variant="outline" size="lg">
-                      Volver al Inicio
-                    </Button>
-                  </Link>
+            <div className="lg:col-span-3">
+              {/* Welcome Message */}
+              <Alert className="mb-8">
+                <Info className="h-4 w-4" />
+                <AlertDescription>
+                  <strong>Bienvenido a SafeSpace.</strong> Estás explorando como visitante.
+                  Puedes leer todos los temas y ver cómo nuestra comunidad se apoya mutuamente.
+                  Si deseas participar activamente, puedes unirte de forma anónima en cualquier momento.
+                </AlertDescription>
+              </Alert>
+
+              {/* Categories */}
+              <section className="mb-12">
+                <div className="flex items-center justify-between mb-6">
+                  <h2 className="text-2xl font-bold text-foreground">Categorías de Apoyo</h2>
+                  <Badge variant="outline">Solo lectura</Badge>
                 </div>
-              </CardContent>
-            </Card>
+
+                {categoriesLoading ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                      <Card key={i} className="animate-pulse">
+                        <CardContent className="p-6">
+                          <div className="h-6 bg-muted rounded mb-4"></div>
+                          <div className="h-4 bg-muted rounded mb-2"></div>
+                          <div className="h-4 bg-muted rounded w-3/4"></div>
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
+                ) : categories && categories.length > 0 ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {categories.map((category: any) => (
+                      <CategoryCard
+                        key={category.id}
+                        category={{
+                          ...category,
+                          stats: {
+                            threadCount: Math.floor(Math.random() * 200) + 50,
+                            postCount: Math.floor(Math.random() * 1000) + 200,
+                            memberCount: Math.floor(Math.random() * 500) + 100,
+                          },
+                          subforums: category.subforums || []
+                        }}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <Card>
+                    <CardContent className="p-12 text-center">
+                      <MessageCircle className="mx-auto mb-4 text-muted-foreground" size={48} />
+                      <h3 className="text-xl font-semibold mb-2">Aún no hay categorías</h3>
+                      <p className="text-muted-foreground">
+                        La comunidad está en proceso de configuración. Pronto habrá espacios de apoyo disponibles.
+                      </p>
+                    </CardContent>
+                  </Card>
+                )}
+              </section>
+
+              {/* Recent Activity */}
+              <section>
+                <div className="flex items-center justify-between mb-6">
+                  <h2 className="text-2xl font-bold text-foreground">Actividad Reciente</h2>
+                  <Badge variant="outline">Últimas 24 horas</Badge>
+                </div>
+
+                <RecentActivity />
+              </section>
+
+              {/* Join CTA */}
+              <Card className="mt-12 bg-gradient-to-r from-primary/10 to-purple-600/10 border-primary/20">
+                <CardContent className="p-8 text-center">
+                  <Heart className="mx-auto mb-4 text-primary" size={48} />
+                  <h3 className="text-2xl font-bold mb-4">¿Listo para Unirte a la Comunidad?</h3>
+                  <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
+                    Has visto cómo nuestra comunidad se apoya mutuamente. Únete de forma anónima
+                    para participar en conversaciones, crear temas y recibir apoyo personalizado.
+                  </p>
+                  <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                    <a href="/api/login">
+                      <Button size="lg" className="bg-primary hover:bg-primary/90">
+                        <UserPlus className="mr-2" size={20} />
+                        Unirse de Forma Anónima
+                      </Button>
+                    </a>
+                    <Link href="/">
+                      <Button variant="outline" size="lg">
+                        Volver al Inicio
+                      </Button>
+                    </Link>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
           </div>
-        </div>
-      </main>
-      
-      </div> {/* Closing div for pt-32 sm:pt-36 */}
-      
+        </main>
+      </div>
+
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- add mock categories, subforums, and recent activity data for forum demos
- load mock categories in forum page and mock activity/subforums in related components
- introduce fixed forum header, modern sidebar styling, and color-coded activity icons for a more professional forum page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: Cannot find module '@/pages/adminJobsPage' and other TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68b4847be6808327bf7ed069a2bdb884

## Summary by Sourcery

Use mock forum data for demos and enhance the forum page layout with a fixed header, refreshed sidebar design, and color-coded activity icons.

New Features:
- Add mock forum datasets for categories, subforums, and recent activity
- Integrate mock data into ForosPage, RecentActivity, and SubforumList via queryFn and initialData

Enhancements:
- Implement a fixed gradient header with navigation and crisis banner
- Revamp sidebar cards with gradient styling, shadows, and sticky positioning
- Introduce CSS utility classes for color-coded activity icons